### PR TITLE
fix browser()

### DIFF
--- a/lib/Plack/Builder/Conditionals.pm
+++ b/lib/Plack/Builder/Conditionals.pm
@@ -138,7 +138,6 @@ sub header {
 }
 
 sub browser {
-    my $header = shift;
     _match( "HTTP_USER_AGENT", @_ );
 }
 

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -33,7 +33,7 @@ ok( header('X-Foo', '!', '100')->({  HTTP_X_BAA => '100' }) );
 ok( header('X-Foo',qr/\d+/)->({  HTTP_X_FOO => '100' }) );
 
 ok( browser(qr/MSIE/)->({ HTTP_USER_AGENT => 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0)' }) );
-ok( ! browser('!',qr!^Mozilla/4!)->({ HTTP_USER_AGENT => 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)' }) );
+ok( browser('!',qr!^Mozilla/4!)->({ HTTP_USER_AGENT => 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)' }) );
 
 
 


### PR DESCRIPTION
browser() function doesn't work correctly because it does not pass first argument to _match().

This patch fixes it.
